### PR TITLE
Add "strings" to boomer_zeromq.go

### DIFF
--- a/boomer_zeromq.go
+++ b/boomer_zeromq.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"runtime"
 	"syscall"
+	"strings"
 )
 
 func Run(tasks ...*Task) {


### PR DESCRIPTION
On MacOS and now on Alpine Linux, when I compile my go code using go build -tags 'zeromq' -o a.out file.go, I get an error saying that "strings" in this file is undefined. Adding the strings dependency alleviates this.