### PR TITLE
Initial count of response time and num reqs should be 1

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -89,7 +89,7 @@ func (s *statsEntry) logTimeOfRequest() {
 
 	_, ok := s.numReqsPerSec[now]
 	if !ok {
-		s.numReqsPerSec[now] = 0
+		s.numReqsPerSec[now] = 1
 	} else {
 		s.numReqsPerSec[now] += 1
 	}
@@ -127,7 +127,7 @@ func (s *statsEntry) logResponseTime(responseTime float64) {
 
 	_, ok := s.responseTimes[roundedResponseTime]
 	if !ok {
-		s.responseTimes[roundedResponseTime] = 0
+		s.responseTimes[roundedResponseTime] = 1
 	} else {
 		s.responseTimes[roundedResponseTime] += 1
 	}


### PR DESCRIPTION
This change matches the behavior of locust, the two map should have initial value of 1, not 0

Value of 0 with slow client will crash locustio when it tries to calculate median_response_time