### PR TITLE
Add a run argument that generate requests based on rate

### DIFF
--- a/boomer.go
+++ b/boomer.go
@@ -19,6 +19,7 @@ var masterPort int
 
 var maxRPS int64
 var requestIncreaseRate string
+var hatchBaseOnRate bool
 var runTasks string
 var memoryProfile string
 var memoryProfileDuration time.Duration
@@ -78,7 +79,7 @@ func Run(tasks ...*Task) {
 	initBoomer()
 	initMutex.Unlock()
 
-	runner := newRunner(tasks, maxRPS, requestIncreaseRate)
+	runner := newRunner(tasks, maxRPS, requestIncreaseRate, hatchBaseOnRate)
 	runner.masterHost = masterHost
 	runner.masterPort = masterPort
 	runner.getReady()
@@ -141,9 +142,10 @@ func startCPUProfile(file string, duration time.Duration) {
 func init() {
 	flag.Int64Var(&maxRPS, "max-rps", 0, "Max RPS that boomer can generate, disabled by default.")
 	flag.StringVar(&requestIncreaseRate, "request-increase-rate", "-1", "Request increase rate, disabled by default.")
+	flag.BoolVar(&hatchBaseOnRate, "hatch-base-on-rate", false, "generate requests based on rate,these requests are sent  well-proportioned in one second instead of a mere instant at the beginning of the second and closed by default.")
 	flag.StringVar(&runTasks, "run-tasks", "", "Run tasks without connecting to the master, multiply tasks is separated by comma. Usually, it's for debug purpose.")
 	flag.StringVar(&masterHost, "master-host", "127.0.0.1", "Host or IP address of locust master for distributed load testing. Defaults to 127.0.0.1.")
-	flag.IntVar(&masterPort, "master-port", 5557, "The port to connect to that is used by the locust master for distributed load testing. Defaults to 5557.")
+	flag.IntVar(&masterPort, "master-port", 5557, "The port to connect to that is used by the locust master for distributed load testing. Defaults to 5558.")
 	flag.StringVar(&memoryProfile, "mem-profile", "", "Enable memory profiling.")
 	flag.DurationVar(&memoryProfileDuration, "mem-profile-duration", 30*time.Second, "Memory profile duration. Defaults to 30 seconds.")
 	flag.StringVar(&cpuProfile, "cpu-profile", "", "Enable CPU profiling.")

--- a/runner_test.go
+++ b/runner_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParseRPSControlArgs(t *testing.T) {
-	r := newRunner(nil, int64(100), "100/2s")
+	r := newRunner(nil, int64(100), "100/2s", false)
 	defer r.close()
 	r.parseRPSControlArgs()
 
@@ -54,7 +54,7 @@ func TestSpawnGoRoutines(t *testing.T) {
 		Name: "TaskB",
 	}
 	tasks := []*Task{taskA, taskB}
-	runner := newRunner(tasks, 100, "-1")
+	runner := newRunner(tasks, 100, "-1", false)
 	defer runner.close()
 	runner.client = newClient("localhost", 5557)
 	runner.hatchRate = 10
@@ -76,7 +76,7 @@ func TestHatchAndStop(t *testing.T) {
 		},
 	}
 	tasks := []*Task{taskA, taskB}
-	runner := newRunner(tasks, 100, "-1")
+	runner := newRunner(tasks, 100, "-1", false)
 	defer runner.close()
 	runner.client = newClient("localhost", 5557)
 
@@ -126,7 +126,7 @@ func TestOnMessage(t *testing.T) {
 		},
 	}
 	tasks := []*Task{taskA, taskB}
-	runner := newRunner(tasks, 100, "-1")
+	runner := newRunner(tasks, 100, "-1", false)
 	defer runner.close()
 	runner.client = newClient("localhost", 5557)
 	runner.state = stateInit
@@ -209,7 +209,7 @@ func TestOnMessage(t *testing.T) {
 }
 
 func TestStartBucketUpdater(t *testing.T) {
-	r := newRunner(nil, 100, "-1")
+	r := newRunner(nil, 100, "-1", false)
 	defer r.close()
 	r.parseRPSControlArgs()
 	r.startBucketUpdater()
@@ -225,7 +225,7 @@ func TestStartBucketUpdater(t *testing.T) {
 }
 
 func TestRPSController(t *testing.T) {
-	r := newRunner(nil, 1000, "-1")
+	r := newRunner(nil, 1000, "-1", false)
 	defer r.close()
 	r.parseRPSControlArgs()
 	r.startRPSController()
@@ -238,7 +238,7 @@ func TestRPSController(t *testing.T) {
 }
 
 func TestRPSControllerWithIncreaseRate(t *testing.T) {
-	r := newRunner(nil, 1000, "200/1s")
+	r := newRunner(nil, 1000, "200/1s", false)
 	defer r.close()
 	r.parseRPSControlArgs()
 	r.startRPSController()
@@ -258,7 +258,7 @@ func TestGetReady(t *testing.T) {
 	defer server.close()
 	server.start()
 
-	r := newRunner(nil, 100, "-1")
+	r := newRunner(nil, 100, "-1", false)
 	r.masterHost = masterHost
 	r.masterPort = masterPort
 	defer r.close()


### PR DESCRIPTION
增加了一个运行参数，根据master下发的rate来生成请求，请求会在整个一秒中平均发送而不会集中在一秒最开端的极短时间内发送，默认是关闭的。
Generated based on rate,requests would be sent evenly during one second(the sending time),instead of being sent at the very beginning of the second.