### PR TITLE
Slave boomer does not hatch tasks as expected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - go get github.com/zeromq/gomq
   - go get github.com/google/uuid
   - go get github.com/olekukonko/tablewriter
+  - go get github.com/stretchr/testify/assert
 
 script:
   - go test -timeout 1m -coverprofile=coverage.txt -covermode=atomic

--- a/runner.go
+++ b/runner.go
@@ -165,6 +165,13 @@ func (r *runner) spawnWorkers(spawnCount int, quit chan bool, hatchCompleteFunc 
 
 func (r *runner) getRandomTask() *Task {
 	totalWeight := r.getWeightSum()
+	if totalWeight == 0 {
+		if len(r.tasks) > 0 {
+			return r.tasks[0]
+		}
+		return nil
+	}
+
 	randSrc := rand.New(rand.NewSource(time.Now().UnixNano()))
 	randNum := randSrc.Intn(totalWeight)
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,9 +1,12 @@
 package boomer
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type HitOutput struct {
@@ -113,6 +116,75 @@ func TestSpawnWorkers(t *testing.T) {
 	currentClients := atomic.LoadInt32(&runner.numClients)
 	if currentClients > 3 {
 		t.Error("Spawning goroutines too fast, current count", currentClients)
+	}
+}
+
+func TestSpawnWorkersWithManyTasks(t *testing.T) {
+	var lock sync.Mutex
+	taskCalls := map[string]int{}
+
+	createTask := func(name string, weight int) *Task {
+		return &Task{
+			Name:   name,
+			Weight: weight,
+			Fn: func() {
+				lock.Lock()
+				defer lock.Unlock()
+				taskCalls[name] += 1
+			},
+		}
+	}
+	tasks := []*Task{
+		createTask(`one hundred`, 100),
+		createTask(`ten`, 10),
+		createTask(`one`, 1),
+	}
+
+	runner := newSlaveRunner("localhost", 5557, tasks, nil)
+	defer runner.close()
+
+	runner.client = newClient("localhost", 5557, runner.nodeID)
+
+	const numToSpawn int = 30
+	const hatchRate float64 = 10
+	runner.hatchRate = hatchRate
+
+	go runner.spawnWorkers(numToSpawn, runner.stopChan, runner.hatchComplete)
+	time.Sleep(4 * time.Second)
+
+	currentClients := atomic.LoadInt32(&runner.numClients)
+
+	assert.Equal(t, numToSpawn, int(currentClients))
+	lock.Lock()
+	hundreds := taskCalls[`one hundred`]
+	tens := taskCalls[`ten`]
+	ones := taskCalls[`one`]
+	lock.Unlock()
+
+	total := hundreds + tens + ones
+	t.Logf("total tasks run: %d\n", total)
+
+	assert.True(t, total > 111)
+
+	assert.True(t, ones > 1)
+	actPercentage := float64(ones) / float64(total)
+	expectedPercentage := 1.0 / 111.0
+	if actPercentage > 2*expectedPercentage || actPercentage < 0.5*expectedPercentage {
+		t.Errorf("Unexpected percentage of ones task: exp %v, act %v", expectedPercentage, actPercentage)
+	}
+
+	assert.True(t, tens > 10)
+	actPercentage = float64(tens) / float64(total)
+	expectedPercentage = 10.0 / 111.0
+	if actPercentage > 2*expectedPercentage || actPercentage < 0.5*expectedPercentage {
+		t.Errorf("Unexpected percentage of tens task: exp %v, act %v", expectedPercentage, actPercentage)
+	}
+
+	assert.True(t, hundreds > 100)
+	actPercentage = float64(hundreds) / float64(total)
+	expectedPercentage = 100.0 / 111.0
+	if actPercentage > 2*expectedPercentage || actPercentage < 0.5*expectedPercentage {
+		t.Errorf("Unexpected percentage of hundreds task: exp %v, act %v", expectedPercentage, actPercentage)
 	}
 }
 


### PR DESCRIPTION
### Problem
If I have a slice of tasks each with a given weight, I would expect the slave nodes to each spin up tasks with the relative weight of each task. However, because we _first_ loop through the tasks and then calc the `amount` for each task, there are some tasks that we spin up zero go routines for.

https://github.com/myzhan/boomer/blob/5424d6ac71e4c18b30dc87e5352c9f603abaab81/runner.go#L128-L165

Additionally, I notice `hatchCompleteFunc` might never be called if we send a signal on `quit` (but I don't _need_ that in this PR).

### Solution
Hatch goroutines at the same rate. However, choose the task randomly _after_ the goroutine has been hatched, not before.

@myzhan What would you suggest?