### PR TITLE
适配locust-0.14.4版本对于slave上报current_cpu_usage的更新

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -457,8 +457,10 @@ func (r *slaveRunner) run() {
 		for {
 			select {
 			case <-ticker.C:
+				CPUUsage, _ := GetCurrentCPUUsage()
 				data := map[string]interface{}{
-					"state": r.state,
+					"state":             r.state,
+					"current_cpu_usage": CPUUsage,
 				}
 				r.client.sendChannel() <- newMessage("heartbeat", data, r.nodeID)
 			case <-r.closeChan:

--- a/utils.go
+++ b/utils.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/shirou/gopsutil/process"
 )
 
 func round(val float64, roundOn float64, places int) (newVal float64) {
@@ -89,4 +90,18 @@ func StartCPUProfile(file string, duration time.Duration) (err error) {
 		log.Println("Stop CPU profiling after", duration)
 	})
 	return nil
+}
+
+// GetCurrentCPUUsage get current CPU usage
+func GetCurrentCPUUsage() (float64, error) {
+	currentPid := os.Getpid()
+	p, err := process.NewProcess(int32(currentPid))
+	if err != nil {
+		return 0.0, err
+	}
+	percent, err := p.CPUPercent()
+	if err != nil {
+		return 0.0, err
+	}
+	return percent, nil
 }


### PR DESCRIPTION
locust-0.14.4版本在监听slave的心跳数据时，新增了current_cpu_usage数据的监听，目前版本中只上传了state数据，这就导致master在解析slave的心跳数据时报错KeyError，最终导致master认为该slave处于missing状态