### PR TITLE
Support reloading/re-spawning workers

### DIFF
--- a/boomer_test.go
+++ b/boomer_test.go
@@ -297,11 +297,11 @@ func TestRun(t *testing.T) {
 	server.toClient <- newMessage("hatch", map[string]interface{}{
 		"hatch_rate":  float64(10),
 		"num_clients": int64(10),
-	}, defaultBoomer.slaveRunner.nodeID)
+	}, DefaultBoomer.slaveRunner.nodeID)
 
 	time.Sleep(4 * time.Second)
 
-	defaultBoomer.Quit()
+	DefaultBoomer.Quit()
 
 	if count != 10 {
 		t.Error("count is", count, "expected: 10")
@@ -311,28 +311,28 @@ func TestRun(t *testing.T) {
 func TestRecordSuccess(t *testing.T) {
 	masterHost := "127.0.0.1"
 	masterPort := 5557
-	defaultBoomer = NewBoomer(masterHost, masterPort)
-	defaultBoomer.slaveRunner = newSlaveRunner(masterHost, masterPort, nil, nil)
+	DefaultBoomer = NewBoomer(masterHost, masterPort)
+	DefaultBoomer.slaveRunner = newSlaveRunner(masterHost, masterPort, nil, nil)
 	RecordSuccess("http", "foo", int64(1), int64(10))
 
-	requestSuccessMsg := <-defaultBoomer.slaveRunner.stats.requestSuccessChan
+	requestSuccessMsg := <-DefaultBoomer.slaveRunner.stats.requestSuccessChan
 	if requestSuccessMsg.requestType != "http" {
 		t.Error("Expected: http, got:", requestSuccessMsg.requestType)
 	}
 	if requestSuccessMsg.responseTime != int64(1) {
 		t.Error("Expected: 1, got:", requestSuccessMsg.responseTime)
 	}
-	defaultBoomer = nil
+	DefaultBoomer = nil
 }
 
 func TestRecordFailure(t *testing.T) {
 	masterHost := "127.0.0.1"
 	masterPort := 5557
-	defaultBoomer = NewBoomer(masterHost, masterPort)
-	defaultBoomer.slaveRunner = newSlaveRunner(masterHost, masterPort, nil, nil)
+	DefaultBoomer = NewBoomer(masterHost, masterPort)
+	DefaultBoomer.slaveRunner = newSlaveRunner(masterHost, masterPort, nil, nil)
 	RecordFailure("udp", "bar", int64(2), "udp error")
 
-	requestFailureMsg := <-defaultBoomer.slaveRunner.stats.requestFailureChan
+	requestFailureMsg := <-DefaultBoomer.slaveRunner.stats.requestFailureChan
 	if requestFailureMsg.requestType != "udp" {
 		t.Error("Expected: udp, got:", requestFailureMsg.requestType)
 	}
@@ -342,5 +342,5 @@ func TestRecordFailure(t *testing.T) {
 	if requestFailureMsg.error != "udp error" {
 		t.Error("Expected: udp error, got:", requestFailureMsg.error)
 	}
-	defaultBoomer = nil
+	DefaultBoomer = nil
 }

--- a/legacy.go
+++ b/legacy.go
@@ -61,14 +61,14 @@ func legacySuccessHandler(requestType string, name string, responseTime interfac
 	successRetiredWarning.Do(func() {
 		log.Println("boomer.Events.Publish(\"request_success\") is less performant and deprecated, use boomer.RecordSuccess() instead.")
 	})
-	defaultBoomer.RecordSuccess(requestType, name, convertResponseTime(responseTime), responseLength)
+	DefaultBoomer.RecordSuccess(requestType, name, convertResponseTime(responseTime), responseLength)
 }
 
 func legacyFailureHandler(requestType string, name string, responseTime interface{}, exception string) {
 	failureRetiredWarning.Do(func() {
 		log.Println("boomer.Events.Publish(\"request_failure\") is less performant and deprecated, use boomer.RecordFailure() instead.")
 	})
-	defaultBoomer.RecordFailure(requestType, name, convertResponseTime(responseTime), exception)
+	DefaultBoomer.RecordFailure(requestType, name, convertResponseTime(responseTime), exception)
 }
 
 func initLegacyEventHandlers() {

--- a/legacy_test.go
+++ b/legacy_test.go
@@ -29,13 +29,13 @@ func TestInitEvents(t *testing.T) {
 
 	masterHost := "127.0.0.1"
 	masterPort := 5557
-	defaultBoomer = NewBoomer(masterHost, masterPort)
-	defaultBoomer.slaveRunner = newSlaveRunner(masterHost, masterPort, nil, nil)
+	DefaultBoomer = NewBoomer(masterHost, masterPort)
+	DefaultBoomer.slaveRunner = newSlaveRunner(masterHost, masterPort, nil, nil)
 
 	Events.Publish("request_success", "http", "foo", int64(1), int64(10))
 	Events.Publish("request_failure", "udp", "bar", int64(2), "udp error")
 
-	requestSuccessMsg := <-defaultBoomer.slaveRunner.stats.requestSuccessChan
+	requestSuccessMsg := <-DefaultBoomer.slaveRunner.stats.requestSuccessChan
 	if requestSuccessMsg.requestType != "http" {
 		t.Error("Expected: http, got:", requestSuccessMsg.requestType)
 	}
@@ -43,7 +43,7 @@ func TestInitEvents(t *testing.T) {
 		t.Error("Expected: 1, got:", requestSuccessMsg.responseTime)
 	}
 
-	requestFailureMsg := <-defaultBoomer.slaveRunner.stats.requestFailureChan
+	requestFailureMsg := <-DefaultBoomer.slaveRunner.stats.requestFailureChan
 	if requestFailureMsg.requestType != "udp" {
 		t.Error("Expected: udp, got:", requestFailureMsg.requestType)
 	}

--- a/runner_test.go
+++ b/runner_test.go
@@ -109,8 +109,10 @@ func TestSpawnWorkers(t *testing.T) {
 
 	runner.client = newClient("localhost", 5557, runner.nodeID)
 	runner.hatchRate = 10
+	runner.spawnCount = 10
+	runner.hatchCompleteFunc = runner.hatchComplete
 
-	go runner.spawnWorkers(10, runner.stopChan, runner.hatchComplete)
+	go runner.spawnWorkers(runner.stopChan)
 	time.Sleep(2 * time.Millisecond)
 
 	currentClients := atomic.LoadInt32(&runner.numClients)
@@ -148,8 +150,10 @@ func TestSpawnWorkersWithManyTasks(t *testing.T) {
 	const numToSpawn int = 30
 	const hatchRate float64 = 10
 	runner.hatchRate = hatchRate
+	runner.hatchCompleteFunc = runner.hatchComplete
+	runner.spawnCount = numToSpawn
 
-	go runner.spawnWorkers(numToSpawn, runner.stopChan, runner.hatchComplete)
+	go runner.spawnWorkers(runner.stopChan)
 	time.Sleep(4 * time.Second)
 
 	currentClients := atomic.LoadInt32(&runner.numClients)
@@ -224,8 +228,10 @@ func TestSpawnWorkersWithManyTasksInWeighingTaskSet(t *testing.T) {
 	const numToSpawn int = 30
 	const hatchRate float64 = 10
 	runner.hatchRate = hatchRate
+	runner.spawnCount = numToSpawn
+	runner.hatchCompleteFunc = runner.hatchComplete
 
-	go runner.spawnWorkers(numToSpawn, runner.stopChan, runner.hatchComplete)
+	go runner.spawnWorkers(runner.stopChan)
 	time.Sleep(4 * time.Second)
 
 	currentClients := atomic.LoadInt32(&runner.numClients)


### PR DESCRIPTION
Also exports defaultBoomer; while not strictly required, this allows
end users to keep an handle on the Boomer created by the high level
boomer.Run() (or can assign it a NewStandaloneBoomer for instance).