### PR TITLE
<add>:<add Locust1.03 for Prometheus based on jianhuan>

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -1,7 +1,16 @@
 package main
 
 import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	//"io"
+	//"io/ioutil"
+
 	"log"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -9,17 +18,134 @@ import (
 	"time"
 
 	"github.com/myzhan/boomer"
+	"github.com/valyala/fasthttp"
 )
+
+func createHttpClient() *http.Client{
+	client := &http.Client{
+		Transport : &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			DisableKeepAlives: false,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          10000,
+			MaxIdleConnsPerHost:   10000,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+	return client
+}
+
+var client *http.Client = createHttpClient()
 
 func foo() {
 	start := time.Now()
-	time.Sleep(100 * time.Millisecond)
+
+	var url string = `http://localhost:8080/hello`
+	resp, err := client.Get(url)
+	if err != nil {
+		//log.Println(err)
+		return
+	}
+
+	//all Write calls succeed without doing anything.
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+
+	//fmt.Println(resp.Status)
 	elapsed := time.Since(start)
 
 	// Report your test result as a success, if you write it in python, it will looks like this
 	// events.request_success.fire(request_type="http", name="foo", response_time=100, response_length=10)
-	globalBoomer.RecordSuccess("http", "foo", elapsed.Nanoseconds()/int64(time.Millisecond), int64(10))
+	if resp.StatusCode < 400  {
+		globalBoomer.RecordSuccess("http", "foo", elapsed.Nanoseconds()/int64(time.Millisecond), int64(10))
+	} else {
+		globalBoomer.RecordFailure("http", "foo", elapsed.Nanoseconds()/int64(time.Millisecond), resp.Status)
+	}
+
 }
+
+//use request and response pool
+func foo1(){
+	start := time.Now()
+
+	var req = fasthttp.AcquireRequest()
+	var resp = fasthttp.AcquireResponse()
+	var url string = `http://localhost:8080/hello`
+	req.Header.SetMethod("GET")
+	req.SetRequestURI(url)
+	defer func(){
+		fasthttp.ReleaseResponse(resp)
+		fasthttp.ReleaseRequest(req)
+	}()
+	//client := createHttpClient()
+
+	//statusCode, body, err := client.Get(body,"http://localhost:8080/hello")
+	//resp, err := client.Get("http://localhost:80/hello")
+
+	if err := fasthttp.Do(req, resp);err != nil {
+		//log.Println(err)
+		return
+	}
+
+	//resp.ReleaseBody(0)
+	//all Write calls succeed without doing anything.
+	//io.Copy(ioutil.Discard, resp.body)
+	//resp.body.Close()
+
+	//fmt.Println(resp.Status)
+	elapsed := time.Since(start)
+
+	// Report your test result as a success, if you write it in python, it will looks like this
+	// events.request_success.fire(request_type="http", name="foo", response_time=100, response_length=10)
+	if resp.StatusCode() < 400  {
+		globalBoomer.RecordSuccess("http", "foo", elapsed.Nanoseconds()/int64(time.Millisecond), int64(10))
+	} else {
+		globalBoomer.RecordFailure("http", "foo", elapsed.Nanoseconds()/int64(time.Millisecond), fmt.Sprint(resp.StatusCode()))
+	}
+}
+
+//use fasthttp.Client
+var fast_client *fasthttp.Client = &fasthttp.Client{
+	MaxConnsPerHost: 10000,
+}
+
+func foo2(){
+	start := time.Now()
+
+
+	var url string = `http://localhost:8080/hello`
+
+
+	statusCode, _, err := fast_client.Get(nil,url)
+	if err != nil {
+		//log.Println(err)
+		return
+	}
+
+	//resp.ReleaseBody(0)
+	//all Write calls succeed without doing anything.
+	//io.Copy(ioutil.Discard, resp.body)
+	//resp.body.Close()
+
+	//fmt.Println(resp.Status)
+	elapsed := time.Since(start)
+
+	// Report your test result as a success, if you write it in python, it will looks like this
+	// events.request_success.fire(request_type="http", name="foo", response_time=100, response_length=10)
+	if statusCode < 400  {
+		globalBoomer.RecordSuccess("http", "foo", elapsed.Nanoseconds()/int64(time.Millisecond), int64(10))
+	} else {
+		globalBoomer.RecordFailure("http", "foo", elapsed.Nanoseconds()/int64(time.Millisecond), fmt.Sprint(statusCode))
+	}
+}
+
 
 func bar() {
 	start := time.Now()
@@ -61,18 +187,25 @@ func main() {
 
 	task1 := &boomer.Task{
 		Name:   "foo",
+		// The weight is used to distribute goroutines over multiple tasks.
 		Weight: 10,
-		Fn:     foo,
+		Fn:     foo2,
 	}
 
-	task2 := &boomer.Task{
-		Name:   "bar",
-		Weight: 30,
-		Fn:     bar,
-	}
+	//task2 := &boomer.Task{
+	//	Name:   "bar",
+	//	Weight: 30,
+	//	Fn:     bar,
+	//}
 
-	globalBoomer.Run(task1, task2)
+	//globalBoomer.Run(task1, task2)
+	globalBoomer.Run(task1)
 
 	waitForQuit()
 	log.Println("shut down")
+
 }
+
+
+
+

--- a/prometheus_exporter.py
+++ b/prometheus_exporter.py
@@ -4,7 +4,7 @@ import six
 from itertools import chain
 
 from flask import request, Response
-from locust import User, task, web, runners, stats as locust_stats
+from locust import User, task, web, runners, stats as locust_stats, event,events, env,clients
 from prometheus_client import Metric, REGISTRY, exposition
 
 # This locustfile adds an external web endpoint to the locust master, and makes it serve as a prometheus exporter.
@@ -13,95 +13,114 @@ from prometheus_client import Metric, REGISTRY, exposition
 
 # Lots of code taken from [mbolek's locust_exporter](https://github.com/mbolek/locust_exporter), thx mbolek!
 
+locust_runner = None
+
+
+@events.init.add_listener
+def on_locust_init(runner, **kw):
+    global locust_runner
+    locust_runner = runner
+    print(runner.state)
+
 
 class LocustCollector(object):
     registry = REGISTRY
 
     def collect(self):
+        runner = locust_runner
         # collect metrics only when locust runner is hatching or running.
-        if runners.locust_runner and runners.locust_runner.state in (runners.STATE_HATCHING, runners.STATE_RUNNING):
+        # print("-----------------------------------")
+        # print(runner)
+        if type(runner) == runners.MasterRunner:    # AttributeError: 'NoneType' object has no attribute 'state'
+            # print("*********************************")
+            # print(runner.state)
+            if runner.state in (runners.STATE_HATCHING, runners.STATE_RUNNING):
 
-            stats = []
+                stats = []
 
-            for s in chain(locust_stats.sort_stats(runners.locust_runner.request_stats),
-                           [runners.locust_runner.stats.total]):
-                stats.append({
-                    "method": s.method,
-                    "name": s.name,
-                    "num_requests": s.num_requests,
-                    "num_failures": s.num_failures,
-                    "avg_response_time": s.avg_response_time,
-                    "min_response_time": s.min_response_time or 0,
-                    "max_response_time": s.max_response_time,
-                    "current_rps": s.current_rps,
-                    "median_response_time": s.median_response_time,
-                    "ninetieth_response_time": s.get_response_time_percentile(0.9),
-                    # only total stats can use current_response_time, so sad.
-                    #"current_response_time_percentile_95": s.get_current_response_time_percentile(0.95),
-                    "avg_content_length": s.avg_content_length,
-                    "current_fail_per_sec": s.current_fail_per_sec
-                })
+                for s in chain(locust_stats.sort_stats(runner.stats.entries),
+                               [runner.stats.total]):
+                    stats.append({
+                        "method": s.method,
+                        "name": s.name,
+                        "num_requests": s.num_requests,
+                        "num_failures": s.num_failures,
+                        "avg_response_time": s.avg_response_time,
+                        "min_response_time": s.min_response_time or 0,
+                        "max_response_time": s.max_response_time,
+                        "current_rps": s.current_rps,
+                        "median_response_time": s.median_response_time,
+                        "ninetieth_response_time": s.get_response_time_percentile(0.9),
+                        # only total stats can use current_response_time, so sad.
+                        #"current_response_time_percentile_95": s.get_current_response_time_percentile(0.95),
+                        "avg_content_length": s.avg_content_length,
+                        "current_fail_per_sec": s.current_fail_per_sec
+                    })
 
-            # perhaps StatsError.parse_error in e.to_dict only works in python slave, take notices!
-            errors = [e.to_dict() for e in six.itervalues(runners.locust_runner.errors)]
+                # perhaps StatsError.parse_error in e.to_dict only works in python slave, take notices!
+                errors = [e.to_dict() for e in six.itervalues(runner.errors)]
 
-            metric = Metric('locust_user_count', 'Swarmed users', 'gauge')
-            metric.add_sample('locust_user_count', value=runners.locust_runner.user_count, labels={})
-            yield metric
-            
-            metric = Metric('locust_errors', 'Locust requests errors', 'gauge')
-            for err in errors:
-                metric.add_sample('locust_errors', value=err['occurrences'],
-                                  labels={'path': err['name'], 'method': err['method'],
-                                          'error': err['error']})
-            yield metric
-
-            is_distributed = isinstance(runners.locust_runner, runners.MasterLocustRunner)
-            if is_distributed:
-                metric = Metric('locust_slave_count', 'Locust number of slaves', 'gauge')
-                metric.add_sample('locust_slave_count', value=len(runners.locust_runner.clients.values()), labels={})
+                metric = Metric('locust_user_count', 'Swarmed users', 'gauge')
+                metric.add_sample('locust_user_count', value=runner.user_count, labels={})
                 yield metric
 
-            metric = Metric('locust_fail_ratio', 'Locust failure ratio', 'gauge')
-            metric.add_sample('locust_fail_ratio', value=runners.locust_runner.stats.total.fail_ratio, labels={})
-            yield metric
-
-            metric = Metric('locust_state', 'State of the locust swarm', 'gauge')
-            metric.add_sample('locust_state', value=1, labels={'state': runners.locust_runner.state})
-            yield metric
-
-            stats_metrics = ['avg_content_length', 'avg_response_time', 'current_rps', 'current_fail_per_sec',
-                             'max_response_time', 'ninetieth_response_time', 'median_response_time', 'min_response_time',
-                             'num_failures', 'num_requests']
-
-            for mtr in stats_metrics:
-                mtype = 'gauge'
-                if mtr in ['num_requests', 'num_failures']:
-                    mtype = 'counter'
-                metric = Metric('locust_stats_' + mtr, 'Locust stats ' + mtr, mtype)
-                for stat in stats:
-                    # Aggregated stat's method label is None, so name it as Aggregated
-                    # locust has changed name Total to Aggregated since 0.12.1
-                    if 'Aggregated' != stat['name']:
-                        metric.add_sample('locust_stats_' + mtr, value=stat[mtr],
-                                          labels={'path': stat['name'], 'method': stat['method']})
-                    else:
-                        metric.add_sample('locust_stats_' + mtr, value=stat[mtr],
-                                          labels={'path': stat['name'], 'method': 'Aggregated'})
+                metric = Metric('locust_errors', 'Locust requests errors', 'gauge')
+                for err in errors:
+                    metric.add_sample('locust_errors', value=err['occurrences'],
+                                      labels={'path': err['name'], 'method': err['method'],
+                                              'error': err['error']})
                 yield metric
 
+                is_distributed = isinstance(runner, runners.MasterRunner)
+                if is_distributed:
+                    metric = Metric('locust_slave_count', 'Locust number of slaves', 'gauge')
+                    metric.add_sample('locust_slave_count', value=len(runner.clients.values()), labels={})
+                    yield metric
 
-@web.app.route("/export/prometheus")
-def prometheus_exporter():
-    registry = REGISTRY
-    encoder, content_type = exposition.choose_encoder(request.headers.get('Accept'))
-    if 'name[]' in request.args:
-        registry = REGISTRY.restricted_registry(request.args.get('name[]'))
-    body = encoder(registry)
-    return Response(body, content_type=content_type)
+                metric = Metric('locust_fail_ratio', 'Locust failure ratio', 'gauge')
+                metric.add_sample('locust_fail_ratio', value=runner.stats.total.fail_ratio, labels={})
+                yield metric
+
+                metric = Metric('locust_state', 'State of the locust swarm', 'gauge')
+                metric.add_sample('locust_state', value=1, labels={'state': runner.state})
+                yield metric
+
+                stats_metrics = ['avg_content_length', 'avg_response_time', 'current_rps', 'current_fail_per_sec',
+                                 'max_response_time', 'ninetieth_response_time', 'median_response_time', 'min_response_time',
+                                 'num_failures', 'num_requests']
+
+                for mtr in stats_metrics:
+                    mtype = 'gauge'
+                    if mtr in ['num_requests', 'num_failures']:
+                        mtype = 'counter'
+                    metric = Metric('locust_stats_' + mtr, 'Locust stats ' + mtr, mtype)
+                    for stat in stats:
+                        # Aggregated stat's method label is None, so name it as Aggregated
+                        # locust has changed name Total to Aggregated since 0.12.1
+                        if 'Aggregated' != stat['name']:
+                            metric.add_sample('locust_stats_' + mtr, value=stat[mtr],
+                                              labels={'path': stat['name'], 'method': stat['method']})
+                        else:
+                            metric.add_sample('locust_stats_' + mtr, value=stat[mtr],
+                                              labels={'path': stat['name'], 'method': 'Aggregated'})
+                    yield metric
 
 
-REGISTRY.register(LocustCollector())
+@events.init.add_listener
+def on_locust_init(web_ui, **kw):
+    if type(web_ui) == web.WebUI:  # @web_ui.app.route("/export/prometheus")  AttributeError: 'NoneType' object has no attribute 'app'
+        @web_ui.app.route("/export/prometheus")
+        def prometheus_exporter():
+            registry = REGISTRY
+            encoder, content_type = exposition.choose_encoder(request.headers.get('Accept'))
+            if 'name[]' in request.args:
+                registry = REGISTRY.restricted_registry(request.args.get('name[]'))
+            body = encoder(registry)
+            return Response(body, content_type=content_type)
+
+
+REGISTRY.register(LocustCollector())  # 注册Prometheus
+
 
 class Dummy(User):
     @task(20)


### PR DESCRIPTION
首先特别感谢 myzhan 和 见欢 做所的工作！
当前的 prometheus_exporter.py 基于locust 0.14版本，由于自己使用了locust 1.03，两个版本的API有一些变化导致prometheus_exporter.py 编译出了问题，所以我尝试使用Locust 1.03的API修改了prometheus_exporter.py，命名为 prometheus1_exporter.py。 另外我部署的Prometheus为2.18.1， https://bugvanisher.github.io/2020/04/05/locust-with-prometheus-and-grafana/ 中的yml配置不适用，有一些小的变化。变动如下：

```
scrape_configs:
  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
  - job_name: 'prometheus'

    # metrics_path defaults to '/metrics'
    # scheme defaults to 'http'.

    static_configs:
    - targets: ['localhost:9090']

  - job_name: 'locust'
  
    metrics_path : /export/prometheus
    static_configs:
    - targets: ['localhost:8089']
```