### PR TITLE
fix: workers 0 is valid from the master

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -345,17 +345,13 @@ func (r *slaveRunner) onHatchMessage(msg *message) {
 	} else {
 		workers = int(users.(int64))
 	}
-	if workers == 0 || hatchRate == 0 {
-		log.Printf("Invalid hatch message from master, users is %d, hatch_rate is %.2f\n",
-			workers, hatchRate)
-	} else {
-		Events.Publish("boomer:hatch", workers, hatchRate)
 
-		if r.rateLimitEnabled {
-			r.rateLimiter.Start()
-		}
-		r.startHatching(workers, hatchRate, r.hatchComplete)
+	Events.Publish("boomer:hatch", workers, hatchRate)
+
+	if r.rateLimitEnabled {
+		r.rateLimiter.Start()
 	}
+	r.startHatching(workers, hatchRate, r.hatchComplete)
 }
 
 // Runner acts as a state machine.


### PR DESCRIPTION
When scaling, if not all nodes will get users, the master will still
send a hatch request for 0 users. Without this fix the worker crashes
and the master ends up losing track of the number of active workers.