### PR TITLE
Publish connect:fail event when connect fails

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -151,7 +151,7 @@ func (r *runner) spawnWorkers(spawnCount int, quit chan bool, spawnCompleteFunc 
 			}()
 		}
 	}
-	
+
 	if spawnCompleteFunc != nil {
 		spawnCompleteFunc()
 	}

--- a/runner.go
+++ b/runner.go
@@ -423,6 +423,7 @@ func (r *slaveRunner) run() {
 		} else {
 			log.Printf("Failed to connect to master(%s:%d) with error %v\n", r.masterHost, r.masterPort, err)
 		}
+		Events.Publish("connect:fail")
 		return
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -345,6 +345,30 @@ func TestStop(t *testing.T) {
 	}
 }
 
+func TestConnectFail(t *testing.T) {
+	taskA := &Task{
+		Fn: func() {
+			time.Sleep(time.Second)
+		},
+	}
+	tasks := []*Task{taskA}
+	runner := newSlaveRunner("localhost", 5557, tasks, nil)
+	runner.stopChan = make(chan bool)
+
+	failed := false
+	handler := func() {
+		failed = true
+	}
+	Events.Subscribe("connect:fail", handler)
+	defer Events.Unsubscribe("connect:fail", handler)
+
+	runner.stop()
+
+	if failed != true {
+		t.Error("Expected stopped to be true, was", failed)
+	}
+}
+
 func TestOnSpawnMessage(t *testing.T) {
 	taskA := &Task{
 		Fn: func() {


### PR DESCRIPTION
This is to make it easier to do error checking in async and means that one doesn't need to read stdout and do an string match on error logs