### PR TITLE
Start spawning if workers == 0

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -358,10 +358,6 @@ func (r *slaveRunner) sumUsersAmount(msg *genericMessage) int {
 func (r *slaveRunner) onSpawnMessage(msg *genericMessage) {
 	r.client.sendChannel() <- newGenericMessage("spawning", nil, r.nodeID)
 	workers := r.sumUsersAmount(msg)
-	if workers == 0 {
-		// Unexpected value, ignore.
-		return
-	}
 
 	if r.rateLimitEnabled {
 		r.rateLimiter.Start()


### PR DESCRIPTION
Fixes a bug seen using locust 2.4.1 a spawn rate less than the number of workers
1. some workers receive a spawn message from locust with 0 users so it ignored - but still goes into state `stateSpawning`
2. after a second or so receives a second spawn message from locust, which calls `r.stop()`
3. `r.stop()` runs `close(r.stopChan)` though as `r.stopChan` is nil (due to the early break in 1.) this panics

Environment:
* Go version: 1.14
* OS alpine3.13

The only consequence of removing this check I can see of this change is publishing `boomer:spawn` even if users is zero. Comparing running a locust worker it also receives a spawn request for 0 workers (`Spawning additional {} ({"QuickstartUser": 0} already running)...`).