### PR TITLE
implement transaction mechanism

### DIFF
--- a/boomer.go
+++ b/boomer.go
@@ -136,22 +136,24 @@ func (b *Boomer) Run(tasks ...*Task) {
 }
 
 // RecordTransaction reports a transaction stat.
-func (b *Boomer) RecordTransaction(name string, totalElapsedTime int64, totalResponseLength int64) {
+func (b *Boomer) RecordTransaction(name string, success bool, elapsedTime int64, contentSize int64) {
 	if b.localRunner == nil && b.slaveRunner == nil {
 		return
 	}
 	switch b.mode {
 	case DistributedMode:
 		b.slaveRunner.stats.transactionChan <- &transaction{
-			name:                name,
-			totalElapsedTime:    totalElapsedTime,
-			totalResponseLength: totalResponseLength,
+			name:        name,
+			success:     success,
+			elapsedTime: elapsedTime,
+			contentSize: contentSize,
 		}
 	case StandaloneMode:
 		b.localRunner.stats.transactionChan <- &transaction{
-			name:                name,
-			totalElapsedTime:    totalElapsedTime,
-			totalResponseLength: totalResponseLength,
+			name:        name,
+			success:     success,
+			elapsedTime: elapsedTime,
+			contentSize: contentSize,
 		}
 	}
 }

--- a/boomer.go
+++ b/boomer.go
@@ -135,6 +135,27 @@ func (b *Boomer) Run(tasks ...*Task) {
 	}
 }
 
+// RecordTransaction reports a transaction stat.
+func (b *Boomer) RecordTransaction(name string, totalElapsedTime int64, totalResponseLength int64) {
+	if b.localRunner == nil && b.slaveRunner == nil {
+		return
+	}
+	switch b.mode {
+	case DistributedMode:
+		b.slaveRunner.stats.transactionChan <- &transaction{
+			name:                name,
+			totalElapsedTime:    totalElapsedTime,
+			totalResponseLength: totalResponseLength,
+		}
+	case StandaloneMode:
+		b.localRunner.stats.transactionChan <- &transaction{
+			name:                name,
+			totalElapsedTime:    totalElapsedTime,
+			totalResponseLength: totalResponseLength,
+		}
+	}
+}
+
 // RecordSuccess reports a success.
 func (b *Boomer) RecordSuccess(requestType, name string, responseTime int64, responseLength int64) {
 	if b.localRunner == nil && b.slaveRunner == nil {

--- a/output.go
+++ b/output.go
@@ -216,8 +216,9 @@ func convertData(data map[string]interface{}) (output *dataOutput, err error) {
 		}
 		output.Stats = append(output.Stats, entryOutput)
 	}
+	// sort stats by type
 	sort.Slice(output.Stats, func(i, j int) bool {
-		return output.Stats[i].Name < output.Stats[j].Name
+		return output.Stats[i].Method < output.Stats[j].Method
 	})
 	return
 }

--- a/runner.go
+++ b/runner.go
@@ -355,7 +355,7 @@ func (r *slaveRunner) sumUsersAmount(msg *genericMessage) int {
 // TODO: Since locust 2.0, spawn rate and user count are both handled by master.
 // But user count is divided by user classes defined in locustfile, because locust assumes that
 // master and workers use the same locustfile. Before we find a better way to deal with this,
-// boomer sums up the total amout of users in spawn message and uses task weight to spawn goroutines like before.
+// boomer sums up the total amount of users in spawn message and uses task weight to spawn goroutines like before.
 func (r *slaveRunner) onSpawnMessage(msg *genericMessage) {
 	r.client.sendChannel() <- newGenericMessage("spawning", nil, r.nodeID)
 	workers := r.sumUsersAmount(msg)

--- a/stats.go
+++ b/stats.go
@@ -46,6 +46,7 @@ func newRequestStats() (stats *requestStats) {
 		entries: entries,
 		errors:  errors,
 	}
+	stats.transactionChan = make(chan *transaction, 100)
 	stats.requestSuccessChan = make(chan *requestSuccess, 100)
 	stats.requestFailureChan = make(chan *requestFailure, 100)
 	stats.clearStatsChan = make(chan bool)


### PR DESCRIPTION
This MR implements a new `RecordTransaction` API to record transactions, and output accumulated number of passed/failed transactions in console output and PrometheusPusherOutput.

In the console output, it will print `Accumulated Transactions: XX Passed, XX Failed` as below.

```
Current time: 2021/12/20 22:42:05, Users: 10, Total RPS: 15, Total Fail Ratio: 0.0%
Accumulated Transactions: 4674 Passed, 0 Failed
+--------------+-----------------+------------+---------+--------+---------+------+------+--------------+------------+-------------+
|     TYPE     |      NAME       | # REQUESTS | # FAILS | MEDIAN | AVERAGE | MIN  | MAX  | CONTENT SIZE | # REQS/SEC | # FAILS/SEC |
+--------------+-----------------+------------+---------+--------+---------+------+------+--------------+------------+-------------+
| transaction  | Action          |         20 |       0 |   1500 | 1455.50 | 1422 | 1485 |            0 |          5 |           0 |
| request-GET  | get with params |         21 |       0 |    970 |  970.38 |  947 |  997 |          300 |          5 |           0 |
| request-POST | post form data  |         20 |       0 |    240 |  240.90 |  235 |  250 |          441 |          5 |           0 |
| request-POST | post json data  |         20 |       0 |    240 |  241.00 |  235 |  247 |          420 |          6 |           0 |
| transaction  | tran1           |         21 |       0 |    970 |  971.48 |  947 |  998 |            0 |          5 |           0 |
+--------------+-----------------+------------+---------+--------+---------+------+------+--------------+------------+-------------+
```

And in the PrometheusPushGateway, you can get two new metrics, `transactions_passed` and `transactions_failed`.

![image](https://user-images.githubusercontent.com/3657070/146785064-d92f064e-1fa4-4122-be80-584dcc99ddcf.png)
