### PR TITLE
Add boomer:start and boomer:fail events

### DIFF
--- a/events.go
+++ b/events.go
@@ -3,10 +3,10 @@ package boomer
 import "github.com/asaskevich/EventBus"
 
 const (
-	EVENT_SPAWN = "boomer:spawn"
-	EVENT_STOP  = "boomer:stop"
-	EVENT_QUIT  = "boomer:quit"
-	EVENT_FAIL = "boomer:fail"
+	EVENT_SPAWN   = "boomer:spawn"
+	EVENT_STOP    = "boomer:stop"
+	EVENT_QUIT    = "boomer:quit"
+	EVENT_FAIL    = "boomer:fail"
 	EVENT_STARTED = "boomer:started"
 )
 

--- a/events.go
+++ b/events.go
@@ -6,6 +6,7 @@ const (
 	EVENT_SPAWN = "boomer:spawn"
 	EVENT_STOP  = "boomer:stop"
 	EVENT_QUIT  = "boomer:quit"
+	EVENT_FAIL = "boomer:fail"
 )
 
 // Events is the global event bus instance.

--- a/events.go
+++ b/events.go
@@ -7,7 +7,7 @@ const (
 	EVENT_STOP  = "boomer:stop"
 	EVENT_QUIT  = "boomer:quit"
 	EVENT_FAIL = "boomer:fail"
-	EVENT_CONNECTED = "boomer:connected"
+	EVENT_STARTED = "boomer:started"
 )
 
 // Events is the global event bus instance.

--- a/events.go
+++ b/events.go
@@ -7,6 +7,7 @@ const (
 	EVENT_STOP  = "boomer:stop"
 	EVENT_QUIT  = "boomer:quit"
 	EVENT_FAIL = "boomer:fail"
+	EVENT_CONNECTED = "boomer:connected"
 )
 
 // Events is the global event bus instance.

--- a/runner.go
+++ b/runner.go
@@ -443,6 +443,7 @@ func (r *slaveRunner) run() {
 		} else {
 			log.Printf("Failed to connect to master(%s:%d) with error %v\n", r.masterHost, r.masterPort, err)
 		}
+		Events.Publish(EVENT_FAIL)
 		return
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -451,6 +451,7 @@ func (r *slaveRunner) run() {
 	r.startListener()
 
 	r.stats.start()
+	Events.Publish(EVENT_CONNECTED)
 	r.outputOnStart()
 
 	if r.rateLimitEnabled {

--- a/runner.go
+++ b/runner.go
@@ -246,6 +246,7 @@ func (r *localRunner) run() {
 	r.state = stateInit
 	r.stats.start()
 	r.outputOnStart()
+	Events.Publish(EVENT_STARTED)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -451,7 +452,7 @@ func (r *slaveRunner) run() {
 	r.startListener()
 
 	r.stats.start()
-	Events.Publish(EVENT_CONNECTED)
+	Events.Publish(EVENT_STARTED)
 	r.outputOnStart()
 
 	if r.rateLimitEnabled {

--- a/runner_test.go
+++ b/runner_test.go
@@ -668,7 +668,7 @@ func TestConnectedEventSlave(t *testing.T) {
 	defer r.shutdown()
 
 	var connected bool
-	err := Events.Subscribe("boomer:connected", func() {
+	err := Events.Subscribe("boomer:started", func() {
 		connected = true
 	})
 	if err != nil {
@@ -678,6 +678,33 @@ func TestConnectedEventSlave(t *testing.T) {
 	r.run()
 
 	if connected != true {
+		t.Error("Expected connected to be true, was", connected)
+	}
+}
+
+
+func TestStartedLocalRunner(t *testing.T) {
+	taskA := &Task{
+		Weight: 10,
+		Fn: func() {
+			time.Sleep(time.Second)
+		},
+		Name: "TaskA",
+	}
+	tasks := []*Task{taskA}
+	runner := newLocalRunner(tasks, nil, 2, 2)
+	var connected bool
+	err := Events.Subscribe("boomer:started", func() {
+		connected = true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	go runner.run()
+	time.Sleep(time.Second)
+	runner.shutdown()
+
+	if !connected{
 		t.Error("Expected connected to be true, was", connected)
 	}
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -677,7 +677,7 @@ func TestConnectedEventSlave(t *testing.T) {
 
 	r.run()
 
-	if connected != true {
+	if !connected{
 		t.Error("Expected connected to be true, was", connected)
 	}
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -654,3 +654,30 @@ func TestFailEvent(t *testing.T) {
 		t.Error("Expected failed to be true, was", failed)
 	}
 }
+
+func TestConnectedEventSlave(t *testing.T) {
+	masterHost := "127.0.0.1"
+	masterPort := 6558
+
+	server := newTestServer(masterHost, masterPort)
+	defer server.close()
+	server.start()
+
+	rateLimiter := NewStableRateLimiter(100, time.Second)
+	r := newSlaveRunner(masterHost, masterPort, nil, rateLimiter)
+	defer r.shutdown()
+
+	var connected bool
+	err := Events.Subscribe("boomer:connected", func() {
+		connected = true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	r.run()
+
+	if connected != true {
+		t.Error("Expected connected to be true, was", connected)
+	}
+}


### PR DESCRIPTION
Adds these two events to make exiting conditions and timeouts are easier to control.

Sort of a continuation of https://github.com/myzhan/boomer/pull/125 although I couldn't get the tests working in that one