### PR TITLE
Support for messages from master, fix spawning behavior

### DIFF
--- a/boomer.go
+++ b/boomer.go
@@ -273,3 +273,17 @@ func RecordSuccess(requestType, name string, responseTime int64, responseLength 
 func RecordFailure(requestType, name string, responseTime int64, exception string) {
 	defaultBoomer.RecordFailure(requestType, name, responseTime, exception)
 }
+
+// SendMessage sends a message to the master.
+// It's a convenience function to use the defaultBoomer.
+func (b *Boomer) SendMessage(msg string, data map[string]interface{}) {
+	switch b.mode {
+	case DistributedMode:
+		if b.slaveRunner != nil {
+			log.Printf("Sending msg `%s`", msg)
+			b.slaveRunner.client.sendChannel() <- newGenericMessage(msg, data, b.slaveRunner.nodeID)
+		} else {
+			log.Panicf("Attempting to send msg `%s` to Master before runner was created.", msg)
+		}
+	}
+}

--- a/boomer.go
+++ b/boomer.go
@@ -280,7 +280,6 @@ func (b *Boomer) SendMessage(msg string, data map[string]interface{}) {
 	switch b.mode {
 	case DistributedMode:
 		if b.slaveRunner != nil {
-			log.Printf("Sending msg `%s`", msg)
 			b.slaveRunner.client.sendChannel() <- newGenericMessage(msg, data, b.slaveRunner.nodeID)
 		} else {
 			log.Panicf("Attempting to send msg `%s` to Master before runner was created.", msg)

--- a/events.go
+++ b/events.go
@@ -3,9 +3,10 @@ package boomer
 import "github.com/asaskevich/EventBus"
 
 const (
-	EVENT_SPAWN = "boomer:spawn"
-	EVENT_STOP  = "boomer:stop"
-	EVENT_QUIT  = "boomer:quit"
+	EVENT_SPAWN  = "boomer:spawn"
+	EVENT_STOP   = "boomer:stop"
+	EVENT_QUIT   = "boomer:quit"
+	EVENT_REPORT = "boomer:report-to-master"
 )
 
 // Events is the global event bus instance.

--- a/runner.go
+++ b/runner.go
@@ -319,7 +319,6 @@ func (r *slaveRunner) spawnComplete() {
 	data["user_classes_count"] = r.userClassesCountFromMaster
 	r.client.sendChannel() <- newGenericMessage("spawning_complete", data, r.nodeID)
 	r.state = stateRunning
-	// fmt.Printf("SPAWN COMPLETE: %v\n", data)
 }
 
 func (r *slaveRunner) onQuiting() {
@@ -366,7 +365,6 @@ func (r *slaveRunner) sumUsersAmount(msg *genericMessage) int {
 // master and workers use the same locustfile. Before we find a better way to deal with this,
 // boomer sums up the total amout of users in spawn message and uses task weight to spawn goroutines like before.
 func (r *slaveRunner) onSpawnMessage(msg *genericMessage) {
-	fmt.Printf("SPAWN_MESSAGE_RECEIVED: %v\n", msg.Data["user_classes_count"])
 	r.client.sendChannel() <- newGenericMessage("spawning", nil, r.nodeID)
 	workers := r.sumUsersAmount(msg)
 	r.startSpawning(workers, float64(workers), r.spawnComplete)

--- a/runner.go
+++ b/runner.go
@@ -483,6 +483,8 @@ func (r *slaveRunner) run() {
 				if r.state == stateInit || r.state == stateStopped {
 					continue
 				}
+				// Publish event to allow adding custom data to be sent to master
+				Events.Publish("boomer:report-to-master", &data)
 				data["user_count"] = r.numClients
 				data["user_classes_count"] = r.userClassesCountFromMaster
 				r.client.sendChannel() <- newGenericMessage("stats", data, r.nodeID)

--- a/runner.go
+++ b/runner.go
@@ -430,7 +430,7 @@ func (r *slaveRunner) onMessage(msgInterface message) {
 	if !handled {
 		// Publish all other messages from master to allow users to subscribe to them.
 		// See: http://docs.locust.io/en/stable/running-distributed.html#communicating-across-nodes
-		Events.Publish(msg.Type, msg)
+		Events.Publish(msg.Type, msg.Data)
 	}
 }
 

--- a/runner.go
+++ b/runner.go
@@ -487,9 +487,11 @@ func (r *slaveRunner) run() {
 			select {
 			case <-ticker.C:
 				CPUUsage := GetCurrentCPUUsage()
+				MemUsage := GetCurrentMemUsage()
 				data := map[string]interface{}{
-					"state":             r.state,
-					"current_cpu_usage": CPUUsage,
+					"state":                r.state,
+					"current_cpu_usage":    CPUUsage,
+					"current_memory_usage": MemUsage,
 				}
 				r.client.sendChannel() <- newGenericMessage("heartbeat", data, r.nodeID)
 			case <-r.shutdownChan:

--- a/runner.go
+++ b/runner.go
@@ -206,8 +206,6 @@ func (r *runner) startSpawning(spawnCount int, spawnRate float64, spawnCompleteF
 
 	r.stopChan = make(chan bool)
 
-	//r.numClients = 0
-
 	go r.spawnWorkers(spawnCount, r.stopChan, spawnCompleteFunc)
 }
 
@@ -389,7 +387,7 @@ func (r *slaveRunner) onMessage(msgInterface message) {
 			r.onSpawnMessage(msg)
 			handled = true
 		case "quit":
-			Events.Publish("boomer:quit")
+			Events.Publish(EVENT_QUIT)
 			handled = true
 		}
 	case stateSpawning:
@@ -398,7 +396,6 @@ func (r *slaveRunner) onMessage(msgInterface message) {
 		switch msg.Type {
 		case "spawn":
 			r.state = stateSpawning
-			//r.stop()
 			r.onSpawnMessage(msg)
 			handled = true
 		case "stop":
@@ -487,7 +484,7 @@ func (r *slaveRunner) run() {
 					continue
 				}
 				// Publish event to allow adding custom data to be sent to master
-				Events.Publish("boomer:report-to-master", &data)
+				Events.Publish(EVENT_REPORT, &data)
 				data["user_count"] = r.numClients
 				data["user_classes_count"] = r.userClassesCountFromMaster
 				r.client.sendChannel() <- newGenericMessage("stats", data, r.nodeID)

--- a/utils.go
+++ b/utils.go
@@ -120,3 +120,11 @@ func GetCurrentCPUUsage() float64 {
 	}
 	return percent / float64(runtime.NumCPU())
 }
+
+func GetCurrentMemUsage() uint64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	// Convert from bytes to megabytes
+	mem := m.Alloc / 1024 / 1024
+	return mem
+}

--- a/utils.go
+++ b/utils.go
@@ -118,13 +118,11 @@ func GetCurrentCPUUsage() float64 {
 		log.Printf("Fail to get CPU percent, %v\n", err)
 		return 0.0
 	}
-	return percent / float64(runtime.NumCPU())
+	return percent
 }
 
 func GetCurrentMemUsage() uint64 {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	// Convert from bytes to megabytes
-	mem := m.Alloc / 1024 / 1024
-	return mem
+	return m.Alloc
 }


### PR DESCRIPTION
Messages from master are published as events that can be subscribed to.

Spawning behavior is fixed. Previously, at each spawning interval Boomer would stop all users and spawn all new ones at the next higher amount. For example, when setting the Locust master to spawn 100 users at 10 per second, Boomer would spawn 10 users one second, then the next second it would stop those 10 users and start 20 new ones, then stop the 20 and start 30, etc. This behavior is inconsistent with how Locust behaves. With this fix, Boomer now correctly only starts 10 new users each second, leaving all previously spawned users as they are.

Additional fixes for reporting CPU and memory usage to master.