### PR TITLE
feat: support customized logger for Boomer, Output and runner

### DIFF
--- a/boomer.go
+++ b/boomer.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var defaultBoomer = &Boomer{}
+var defaultBoomer = &Boomer{logger: log.Default()}
 
 // Mode is the running mode of boomer, both standalone and distributed are supported.
 type Mode int

--- a/boomer.go
+++ b/boomer.go
@@ -24,6 +24,7 @@ const (
 
 // A Boomer is used to run tasks.
 // This type is exposed, so users can create and control a Boomer instance programmatically.
+// A non-nil logger is supposed to be set.
 type Boomer struct {
 	masterHost  string
 	masterPort  int

--- a/boomer_test.go
+++ b/boomer_test.go
@@ -2,6 +2,7 @@ package boomer
 
 import (
 	"flag"
+	"log"
 	"math"
 	"os"
 	"runtime"
@@ -215,7 +216,7 @@ var _ = Describe("Test Boomer", func() {
 
 	It("test record success", func() {
 		defer func() {
-			defaultBoomer = &Boomer{}
+			defaultBoomer = &Boomer{logger: log.Default()}
 		}()
 
 		// called before runner instance created
@@ -245,7 +246,7 @@ var _ = Describe("Test Boomer", func() {
 
 	It("test record failure", func() {
 		defer func() {
-			defaultBoomer = &Boomer{}
+			defaultBoomer = &Boomer{logger: log.Default()}
 		}()
 
 		// called before runner instance created

--- a/boomer_test.go
+++ b/boomer_test.go
@@ -50,8 +50,8 @@ var _ = Describe("Test Boomer", func() {
 
 	It("test add output", func() {
 		b := NewStandaloneBoomer(100, 10)
-		b.AddOutput(NewConsoleOutput(nil))
-		b.AddOutput(NewConsoleOutput(nil))
+		b.AddOutput(NewConsoleOutput())
+		b.AddOutput(NewConsoleOutput())
 		Expect(b.outputs).To(HaveLen(2))
 	})
 

--- a/boomer_test.go
+++ b/boomer_test.go
@@ -275,4 +275,20 @@ var _ = Describe("Test Boomer", func() {
 		Expect(requestFailureMsg.responseTime).To(BeEquivalentTo(2))
 		Expect(requestFailureMsg.error).To(Equal("udp error"))
 	})
+
+	It("test loggers", func() {
+		defer func() {
+			defaultBoomer = &Boomer{logger: log.Default()}
+		}()
+
+		logger := log.New(os.Stdout, "[boomer]", log.LstdFlags)
+
+		defaultBoomer = &Boomer{}
+		defaultBoomer.WithLogger(nil)
+		defaultBoomer.WithLogger(logger)
+
+		defaultBoomer.slaveRunner = &slaveRunner{}
+		defaultBoomer.localRunner = &localRunner{}
+		defaultBoomer.WithLogger(logger)
+	})
 })

--- a/boomer_test.go
+++ b/boomer_test.go
@@ -50,8 +50,8 @@ var _ = Describe("Test Boomer", func() {
 
 	It("test add output", func() {
 		b := NewStandaloneBoomer(100, 10)
-		b.AddOutput(NewConsoleOutput())
-		b.AddOutput(NewConsoleOutput())
+		b.AddOutput(NewConsoleOutput(nil))
+		b.AddOutput(NewConsoleOutput(nil))
 		Expect(b.outputs).To(HaveLen(2))
 	})
 

--- a/output.go
+++ b/output.go
@@ -38,12 +38,17 @@ type ConsoleOutput struct {
 }
 
 // NewConsoleOutput returns a ConsoleOutput.
-// If logger is nil, use log.Default().
-func NewConsoleOutput(logger *log.Logger) *ConsoleOutput {
-	if logger == nil {
-		logger = log.Default()
+func NewConsoleOutput() *ConsoleOutput {
+	return &ConsoleOutput{logger: log.Default()}
+}
+
+// WithLogger allows user to use their own logger.
+// If the logger is nil, it will not take effect.
+func (o *ConsoleOutput) WithLogger(logger *log.Logger) *ConsoleOutput {
+	if logger != nil {
+		o.logger = logger
 	}
-	return &ConsoleOutput{logger: logger}
+	return o
 }
 
 func getMedianResponseTime(numRequests int64, responseTimes map[int64]int64) int64 {
@@ -335,15 +340,20 @@ var (
 )
 
 // NewPrometheusPusherOutput returns a PrometheusPusherOutput.
-// If logger is nil, use log.Default().
-func NewPrometheusPusherOutput(logger *log.Logger, gatewayURL, jobName string) *PrometheusPusherOutput {
-	if logger == nil {
-		logger = log.Default()
-	}
+func NewPrometheusPusherOutput(gatewayURL, jobName string) *PrometheusPusherOutput {
 	return &PrometheusPusherOutput{
 		pusher: push.New(gatewayURL, jobName),
-		logger: logger,
+		logger: log.Default(),
 	}
+}
+
+// WithLogger allows user to use their own logger.
+// If the logger is nil, it will not take effect.
+func (o *PrometheusPusherOutput) WithLogger(logger *log.Logger) *PrometheusPusherOutput {
+	if logger != nil {
+		o.logger = logger
+	}
+	return o
 }
 
 // PrometheusPusherOutput pushes boomer stats to Prometheus Pushgateway.

--- a/output.go
+++ b/output.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 	"sort"
 	"strconv"
 	"time"
@@ -35,11 +34,16 @@ type Output interface {
 
 // ConsoleOutput is the default output for standalone mode.
 type ConsoleOutput struct {
+	logger *log.Logger
 }
 
 // NewConsoleOutput returns a ConsoleOutput.
-func NewConsoleOutput() *ConsoleOutput {
-	return &ConsoleOutput{}
+// If logger is nil, use log.Default().
+func NewConsoleOutput(logger *log.Logger) *ConsoleOutput {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &ConsoleOutput{logger: logger}
 }
 
 func getMedianResponseTime(numRequests int64, responseTimes map[int64]int64) int64 {
@@ -119,14 +123,14 @@ func (o *ConsoleOutput) OnStop() {
 func (o *ConsoleOutput) OnEvent(data map[string]interface{}) {
 	output, err := convertData(data)
 	if err != nil {
-		log.Printf("convert data error: %v\n", err)
+		o.logger.Printf("convert data error: %v\n", err)
 		return
 	}
 
 	currentTime := time.Now()
-	println(fmt.Sprintf("Current time: %s, Users: %d, Total RPS: %d, Total Fail Ratio: %.1f%%",
+	o.logger.Println(fmt.Sprintf("Current time: %s, Users: %d, Total RPS: %d, Total Fail Ratio: %.1f%%",
 		currentTime.Format("2006/01/02 15:04:05"), output.UserCount, output.TotalRPS, output.TotalFailRatio*100))
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(o.logger.Writer())
 	table.SetHeader([]string{"Type", "Name", "# requests", "# fails", "Median", "Average", "Min", "Max", "Content Size", "# reqs/sec", "# fails/sec"})
 
 	for _, stat := range output.Stats {
@@ -145,7 +149,7 @@ func (o *ConsoleOutput) OnEvent(data map[string]interface{}) {
 		table.Append(row)
 	}
 	table.Render()
-	println()
+	o.logger.Println()
 }
 
 type statsEntryOutput struct {
@@ -331,20 +335,26 @@ var (
 )
 
 // NewPrometheusPusherOutput returns a PrometheusPusherOutput.
-func NewPrometheusPusherOutput(gatewayURL, jobName string) *PrometheusPusherOutput {
+// If logger is nil, use log.Default().
+func NewPrometheusPusherOutput(logger *log.Logger, gatewayURL, jobName string) *PrometheusPusherOutput {
+	if logger == nil {
+		logger = log.Default()
+	}
 	return &PrometheusPusherOutput{
 		pusher: push.New(gatewayURL, jobName),
+		logger: logger,
 	}
 }
 
 // PrometheusPusherOutput pushes boomer stats to Prometheus Pushgateway.
 type PrometheusPusherOutput struct {
 	pusher *push.Pusher // Prometheus Pushgateway Pusher
+	logger *log.Logger
 }
 
 // OnStart will register all prometheus metric collectors
 func (o *PrometheusPusherOutput) OnStart() {
-	log.Println("register prometheus metric collectors")
+	o.logger.Println("register prometheus metric collectors")
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(
 		// gauge vectors for requests
@@ -374,7 +384,7 @@ func (o *PrometheusPusherOutput) OnStop() {
 func (o *PrometheusPusherOutput) OnEvent(data map[string]interface{}) {
 	output, err := convertData(data)
 	if err != nil {
-		log.Printf("convert data error: %v\n", err)
+		o.logger.Printf("convert data error: %v\n", err)
 		return
 	}
 
@@ -402,6 +412,6 @@ func (o *PrometheusPusherOutput) OnEvent(data map[string]interface{}) {
 	}
 
 	if err := o.pusher.Push(); err != nil {
-		log.Printf("Could not push to Pushgateway: error: %v\n", err)
+		o.logger.Printf("Could not push to Pushgateway: error: %v\n", err)
 	}
 }

--- a/output.go
+++ b/output.go
@@ -135,7 +135,8 @@ func (o *ConsoleOutput) OnEvent(data map[string]interface{}) {
 	currentTime := time.Now()
 	o.logger.Println(fmt.Sprintf("Current time: %s, Users: %d, Total RPS: %d, Total Fail Ratio: %.1f%%",
 		currentTime.Format("2006/01/02 15:04:05"), output.UserCount, output.TotalRPS, output.TotalFailRatio*100))
-	table := tablewriter.NewWriter(o.logger.Writer())
+	noPrefixLogger := log.New(o.logger.Writer(), "", 0)
+	table := tablewriter.NewWriter(noPrefixLogger.Writer())
 	table.SetHeader([]string{"Type", "Name", "# requests", "# fails", "Median", "Average", "Min", "Max", "Content Size", "# reqs/sec", "# fails/sec"})
 
 	for _, stat := range output.Stats {

--- a/output_test.go
+++ b/output_test.go
@@ -62,7 +62,7 @@ var _ = Describe("test output", func() {
 	})
 
 	It("test console output", func() {
-		o := NewConsoleOutput()
+		o := NewConsoleOutput(nil)
 		o.OnStart()
 
 		data := map[string]interface{}{}

--- a/output_test.go
+++ b/output_test.go
@@ -62,7 +62,7 @@ var _ = Describe("test output", func() {
 	})
 
 	It("test console output", func() {
-		o := NewConsoleOutput(nil)
+		o := NewConsoleOutput()
 		o.OnStart()
 
 		data := map[string]interface{}{}

--- a/output_test.go
+++ b/output_test.go
@@ -1,6 +1,9 @@
 package boomer
 
 import (
+	"log"
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -93,5 +96,18 @@ var _ = Describe("test output", func() {
 		o.OnEvent(data)
 
 		o.OnStop()
+	})
+
+	It("test loggers", func() {
+		o := NewConsoleOutput()
+
+		logger := log.New(os.Stdout, "[boomer]", log.LstdFlags)
+
+		o.WithLogger(nil)
+		o.WithLogger(logger)
+
+		o2 := NewPrometheusPusherOutput("", "")
+		o2.WithLogger(nil)
+		o2.WithLogger(logger)
 	})
 })

--- a/runner.go
+++ b/runner.go
@@ -266,6 +266,7 @@ type localRunner struct {
 
 func newLocalRunner(tasks []*Task, rateLimiter RateLimiter, spawnCount int, spawnRate float64) (r *localRunner) {
 	r = &localRunner{}
+	r.setLogger(log.Default())
 	r.setTasks(tasks)
 	r.spawnRate = spawnRate
 	r.spawnCount = spawnCount
@@ -342,6 +343,7 @@ type slaveRunner struct {
 
 func newSlaveRunner(masterHost string, masterPort int, tasks []*Task, rateLimiter RateLimiter) (r *slaveRunner) {
 	r = &slaveRunner{}
+	r.setLogger(log.Default())
 	r.masterHost = masterHost
 	r.masterPort = masterPort
 	r.setTasks(tasks)

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,6 +1,7 @@
 package boomer
 
 import (
+	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,6 +34,7 @@ var _ = Describe("Test runner", func() {
 	It("test saferun", func() {
 		Expect(func() {
 			runner := &runner{}
+			runner.setLogger(log.Default())
 			runner.safeRun(func() {
 				panic("Runner will catch this panic")
 			})
@@ -43,6 +45,7 @@ var _ = Describe("Test runner", func() {
 		hitOutput := &HitOutput{}
 		hitOutput2 := &HitOutput{}
 		runner := &runner{}
+		runner.setLogger(log.Default())
 		runner.addOutput(hitOutput)
 		runner.addOutput(hitOutput2)
 		runner.outputOnStart()
@@ -54,6 +57,7 @@ var _ = Describe("Test runner", func() {
 		hitOutput := &HitOutput{}
 		hitOutput2 := &HitOutput{}
 		runner := &runner{}
+		runner.setLogger(log.Default())
 		runner.addOutput(hitOutput)
 		runner.addOutput(hitOutput2)
 		runner.outputOnEevent(nil)
@@ -65,6 +69,7 @@ var _ = Describe("Test runner", func() {
 		hitOutput := &HitOutput{}
 		hitOutput2 := &HitOutput{}
 		runner := &runner{}
+		runner.setLogger(log.Default())
 		runner.addOutput(hitOutput)
 		runner.addOutput(hitOutput2)
 		runner.outputOnStop()


### PR DESCRIPTION
The new feature is totally backwards compatible, while it allows user to customize the logger for `Boomer`, `Output` and `runner`.

Added:
- `func (b *Boomer) WithLogger(logger *log.Logger) *Boomer`
- `func (o *XxxOutput) WithLogger(logger *log.Logger) *XxxOutput`