### PR TITLE
fix: yield processor explicitly

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -166,6 +167,7 @@ func (r *runner) addWorkers(gapCount int) {
 							}
 						}
 					}
+					runtime.Gosched()
 				}
 			}(ctx)
 		}


### PR DESCRIPTION
It will spend more time within the potentially continuous goroutine, as we anticipate the scheduler to switch contexts more frequently under high concurrency, especially in the local runner. To address it, we explicitly yield the processor in the loop block with a default statement.

@myzhan  :D 