### PR TITLE
Report memory usage and correct CPU percentage in heartbeat messages

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -619,9 +619,11 @@ func (r *slaveRunner) run() {
 				}
 				// send client heartbeat message
 				CPUUsage := GetCurrentCPUUsage()
+				MemUsage := GetCurrentMemUsage()
 				data := map[string]interface{}{
-					"state":             r.state,
-					"current_cpu_usage": CPUUsage,
+					"state":                r.state,
+					"current_cpu_usage":    CPUUsage,
+					"current_memory_usage": MemUsage,
 				}
 				r.client.sendChannel() <- newGenericMessage("heartbeat", data, r.nodeID)
 			case <-r.shutdownChan:

--- a/utils.go
+++ b/utils.go
@@ -135,7 +135,7 @@ func GetCurrentCPUUsage() float64 {
 		log.Printf("Fail to get CPU percent, %v\n", err)
 		return 0.0
 	}
-	return percent
+	return percent / float64(runtime.NumCPU())
 }
 
 func GetCurrentMemUsage() uint64 {

--- a/utils.go
+++ b/utils.go
@@ -135,13 +135,11 @@ func GetCurrentCPUUsage() float64 {
 		log.Printf("Fail to get CPU percent, %v\n", err)
 		return 0.0
 	}
-	return percent / float64(runtime.NumCPU())
+	return percent
 }
 
 func GetCurrentMemUsage() uint64 {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	// Convert from bytes to megabytes
-	mem := m.Alloc / 1024 / 1024
-	return mem
+	return m.Alloc
 }

--- a/utils.go
+++ b/utils.go
@@ -137,3 +137,11 @@ func GetCurrentCPUUsage() float64 {
 	}
 	return percent / float64(runtime.NumCPU())
 }
+
+func GetCurrentMemUsage() uint64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	// Convert from bytes to megabytes
+	mem := m.Alloc / 1024 / 1024
+	return mem
+}


### PR DESCRIPTION
I am picking up the work related to #165 an will be splitting it out into smaller more digestible PRs as requested. 

The CPU percent change is to bring the stats in line with CPU utilization numbers as reported by tools like top. Usually CPU percentage isn't normalized by CPU count, but it is allowed to exceed 100% if it is loading across multiple cores.