### PR TITLE
Make host url configurable from UI

### DIFF
--- a/_examples/http/client.go
+++ b/_examples/http/client.go
@@ -127,8 +127,10 @@ verbose: %t`, method, url, timeout, postFile, contentType, disableCompression, d
 	}
 
 	// Update the host URL passed from UI
-	boomer.Events.Subscribe(boomer.EVENT_SPAWN3, func(workers int, spawnRate float64, host string) {
-		url = host
+	boomer.Events.Subscribe(boomer.EVENT_CONFIG, func(params map[string]interface{}) {
+		if v, ok := params["host"]; ok {
+			url = v.(string)
+		}
 	})
 
 	task := &boomer.Task{

--- a/_examples/http/client.go
+++ b/_examples/http/client.go
@@ -126,6 +126,11 @@ verbose: %t`, method, url, timeout, postFile, contentType, disableCompression, d
 		Timeout:   time.Duration(timeout) * time.Second,
 	}
 
+	// Update the host URL passed from UI
+	boomer.Events.Subscribe(boomer.EVENT_SPAWN3, func(workers int, spawnRate float64, host string) {
+		url = host
+	})
+
 	task := &boomer.Task{
 		Name:   "worker",
 		Weight: 10,

--- a/events.go
+++ b/events.go
@@ -5,7 +5,7 @@ import "github.com/asaskevich/EventBus"
 const (
 	EVENT_CONNECTED = "boomer:connected"
 	EVENT_SPAWN     = "boomer:spawn"
-	EVENT_SPAWN3    = "boomer:spawn3"
+	EVENT_CONFIG    = "boomer:config"
 	EVENT_STOP      = "boomer:stop"
 	EVENT_QUIT      = "boomer:quit"
 )

--- a/events.go
+++ b/events.go
@@ -5,6 +5,7 @@ import "github.com/asaskevich/EventBus"
 const (
 	EVENT_CONNECTED = "boomer:connected"
 	EVENT_SPAWN     = "boomer:spawn"
+	EVENT_SPAWN3    = "boomer:spawn3"
 	EVENT_STOP      = "boomer:stop"
 	EVENT_QUIT      = "boomer:quit"
 )

--- a/runner.go
+++ b/runner.go
@@ -248,7 +248,9 @@ func (r *runner) getTask(index int) *Task {
 
 func (r *runner) startSpawning(spawnCount int, spawnRate float64, host string, spawnCompleteFunc func()) {
 	Events.Publish(EVENT_SPAWN, spawnCount, spawnRate)
-	Events.Publish(EVENT_SPAWN3, spawnCount, spawnRate, host)
+	Events.Publish(EVENT_CONFIG, map[string]interface{}{
+		"host": host,
+	})
 
 	r.spawnWorkers(spawnCount, spawnCompleteFunc)
 }

--- a/runner.go
+++ b/runner.go
@@ -246,8 +246,9 @@ func (r *runner) getTask(index int) *Task {
 	return r.runTask[index]
 }
 
-func (r *runner) startSpawning(spawnCount int, spawnRate float64, spawnCompleteFunc func()) {
+func (r *runner) startSpawning(spawnCount int, spawnRate float64, host string, spawnCompleteFunc func()) {
 	Events.Publish(EVENT_SPAWN, spawnCount, spawnRate)
+	Events.Publish(EVENT_SPAWN3, spawnCount, spawnRate, host)
 
 	r.spawnWorkers(spawnCount, spawnCompleteFunc)
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -314,38 +314,14 @@ var _ = Describe("Test runner", func() {
 		Events.Subscribe(EVENT_SPAWN, callback)
 		defer Events.Unsubscribe(EVENT_SPAWN, callback)
 
-		runner.onSpawnMessage(newGenericMessage("spawn", map[string]interface{}{
-			"user_classes_count": map[interface{}]interface{}{
-				"Dummy":  int64(10),
-				"Dummy2": int64(10),
-			},
-			"timestamp": 1,
-		}, runner.nodeID))
-
-		Expect(workers).To(BeEquivalentTo(20))
-		Expect(spawnRate).To(BeEquivalentTo(20))
-		runner.onMessage(newGenericMessage("stop", nil, runner.nodeID))
-	})
-
-	It("test on spawn message with three arguments", func() {
-		taskA := &Task{
-			Fn: func() {
-				time.Sleep(time.Second)
-			},
+		host := ""
+		configCallback := func(params map[string]interface{}) {
+			if v, ok := params["host"]; ok {
+				host = v.(string)
+			}
 		}
-		runner := newSlaveRunner("localhost", 5557, []*Task{taskA}, nil)
-		runner.client = newClient("localhost", 5557, runner.nodeID)
-		runner.state = stateInit
-		defer runner.shutdown()
-
-		workers, spawnRate, host := 0, float64(0), ""
-		callback := func(param1 int, param2 float64, param3 string) {
-			workers = param1
-			spawnRate = param2
-			host = param3
-		}
-		Events.Subscribe(EVENT_SPAWN3, callback)
-		defer Events.Unsubscribe(EVENT_SPAWN3, callback)
+		Events.Subscribe(EVENT_CONFIG, configCallback)
+		defer Events.Unsubscribe(EVENT_CONFIG, configCallback)
 
 		runner.onSpawnMessage(newGenericMessage("spawn", map[string]interface{}{
 			"user_classes_count": map[interface{}]interface{}{

--- a/runner_test.go
+++ b/runner_test.go
@@ -257,7 +257,7 @@ var _ = Describe("Test runner", func() {
 		runner.client = newClient("localhost", 5557, runner.nodeID)
 		defer runner.shutdown()
 
-		runner.startSpawning(10, float64(10), runner.spawnComplete)
+		runner.startSpawning(10, float64(10), "http://localhost:8080", runner.spawnComplete)
 		// wait for spawning goroutines
 		time.Sleep(2 * time.Second)
 		Expect(runner.numClients).To(BeEquivalentTo(10))
@@ -324,6 +324,41 @@ var _ = Describe("Test runner", func() {
 
 		Expect(workers).To(BeEquivalentTo(20))
 		Expect(spawnRate).To(BeEquivalentTo(20))
+		runner.onMessage(newGenericMessage("stop", nil, runner.nodeID))
+	})
+
+	It("test on spawn message with three arguments", func() {
+		taskA := &Task{
+			Fn: func() {
+				time.Sleep(time.Second)
+			},
+		}
+		runner := newSlaveRunner("localhost", 5557, []*Task{taskA}, nil)
+		runner.client = newClient("localhost", 5557, runner.nodeID)
+		runner.state = stateInit
+		defer runner.shutdown()
+
+		workers, spawnRate, host := 0, float64(0), ""
+		callback := func(param1 int, param2 float64, param3 string) {
+			workers = param1
+			spawnRate = param2
+			host = param3
+		}
+		Events.Subscribe(EVENT_SPAWN3, callback)
+		defer Events.Unsubscribe(EVENT_SPAWN3, callback)
+
+		runner.onSpawnMessage(newGenericMessage("spawn", map[string]interface{}{
+			"user_classes_count": map[interface{}]interface{}{
+				"Dummy":  int64(10),
+				"Dummy2": int64(10),
+			},
+			"timestamp": 1,
+			"host":      []byte("http://localhost:3000"),
+		}, runner.nodeID))
+
+		Expect(workers).To(BeEquivalentTo(20))
+		Expect(spawnRate).To(BeEquivalentTo(20))
+		Expect(host).To(BeEquivalentTo("http://localhost:3000"))
 		runner.onMessage(newGenericMessage("stop", nil, runner.nodeID))
 	})
 


### PR DESCRIPTION
Related to #177, this PR allows boomer to receive the host url configured in master UI.
When boomer receives the spawn message including `host` field, it publishes a new `boomer:spawn3` event.